### PR TITLE
Skip native tree-sitter builds that fail in hermetic Konflux environment

### DIFF
--- a/Containerfile.console-plugin
+++ b/Containerfile.console-plugin
@@ -36,10 +36,17 @@ COPY kuadrant-console-plugin/package.json kuadrant-console-plugin/yarn.lock ./
 # Use downstream .yarnrc.yml with s390x and ppc64le support
 COPY .yarnrc.yml ./
 
-# Validate a project when using Zero-Installs
-#   $ yarn install --immutable --immutable-cache
-# Validate a project when using Zero-Installs (slightly safer if you accept external PRs)
-#   $ yarn install --immutable --immutable-cache --check-cache
+# Skip native tree-sitter builds — this browser plugin uses the WASM fallback
+# (web-tree-sitter) at runtime, and node-gyp cannot compile in hermetic mode
+RUN node -e " \
+  const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); \
+  pkg.dependenciesMeta = Object.assign(pkg.dependenciesMeta || {}, { \
+    'tree-sitter': { built: false }, \
+    'tree-sitter-json': { built: false }, \
+    '@tree-sitter-grammars/tree-sitter-yaml': { built: false } \
+  }); \
+  require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
+
 RUN yarn install --immutable
 
 # Copy the rest of the contents from upstream repo to container

--- a/Containerfile.console-plugin
+++ b/Containerfile.console-plugin
@@ -47,7 +47,7 @@ RUN node -e " \
   }); \
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
 
-RUN yarn install --immutable
+RUN yarn install
 
 # Copy the rest of the contents from upstream repo to container
 COPY kuadrant-console-plugin/ .


### PR DESCRIPTION

  Added a RUN node -e ... step (lines 41-48) before yarn install that injects dependenciesMeta into package.json to set built: false for tree-sitter, tree-sitter-json, and @tree-sitter-grammars/tree-sitter-yaml. This tells Yarn to
  skip their native build scripts (node-gyp), which fail in the hermetic build because node-gyp can't download Node.js headers without network access.

  This is safe because the console plugin runs in the browser, where web-tree-sitter (the WASM fallback, which is also installed) handles parsing — the native tree-sitter module is never loaded. The fix applies to all architectures
  (x86_64, aarch64, s390x, ppc64le), so the previous workaround of installing a C toolchain is no longer needed.
  
  The --immutable flag rejects any lockfile modification, but we're deliberately modifying package.json in the prior step. Dropping --immutable lets Yarn update the lockfile to reflect the dependenciesMeta
  additions while still using prefetched packages (cachi2 sets YARN_ENABLE_NETWORK=0).
  
  
  The plan is to possibly add the dependenciesMeta upstream before the next release so that we can re-enable the immutable flag.